### PR TITLE
add +crt-static

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,9 +27,11 @@ jobs:
           toolchain: "nightly"
 
       - name: build ext
+        shell: powershell
         run: |
+          $env:RUSTFLAGS="-C target-feature=+crt-static"
           cd ./mpv-easy-ext
-          cargo build --release --out-dir=./output -Z unstable-options
+          cargo build --target x86_64-pc-windows-msvc --release --out-dir=./output -Z unstable-options
           cd ..
           mv ./mpv-easy-ext/output/mpv-easy-ext.exe ./mpv-easy-ext-windows.exe
           mv ./mpv-easy-ext/output/mpv-easy-play-with.exe ./mpv-easy-play-with-windows.exe


### PR DESCRIPTION
https://github.com/mpv-easy/mpv-easy/issues/15#issuecomment-2291521053
Using static linking will increase the size of the program, but it can avoid the problem of not finding the VCRUNTIME140.dll